### PR TITLE
Transaction cancellation

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,8 +1,21 @@
+# reservation commitments
+
+  Node at hop, commits to:
+    - settle (irrevocably issue/credit the funds) if:
+      - it has not yet canceled the transaction.
+      - it is presented with the lock.
+      - node at hop-1 has made the same commitment.
+    - cancel the transaction if:
+      - it has not yet settled the transaction.
+      - node at hop+1 has canceled.
+
 # preview
 
   [ ] finish mint
-    [ ] transaction safe cancelation
+    [ ] async propagation in case of failure
+    [ ] support for 404 on retrieve transaction
     [ ] reintroduce transaction expiry on top of safe cancelation
+    [x] transaction safe cancelation
     [x] mint transaction creation refactor
     [x] setup loggly
     [x] setup LetsEncrypt
@@ -46,7 +59,8 @@
 
 # mint
 
-  [ ] transaction safe cancelation
+  [ ] async propagation in case of failure
+  [ ] support for 404 on retrieve transaction
   [ ] reintroduce transaction expiry on top of safe cancelation
   [~] list endpoint
     [ ] list asset operations
@@ -54,6 +68,7 @@
     [x] list asset balances
     [x] list balances
     [x] list assets
+  [x] transaction safe cancelation
   [x] refactor transaction creation/settlement
   [x] Mint-Protocol-Version header
   [x] default LetsEncrypt SSL cert provisioning in production
@@ -98,6 +113,9 @@
       [ ] B gives different offer price to A and C
       [ ] B fails reservation entirely
       [ ] B pass reservation through but fails responding to C
+      [ ] A settles to C who fails
+    [ ] test same mint multiple uers
+    [ ] test cycles in offer path
     [ ] offer closing + attempt transaction on it
     [ ] offer closing of an offer not owned by caller
     [ ] test that consumes an offer entirely (check status)

--- a/mint/endpoint/cancel_transaction.go
+++ b/mint/endpoint/cancel_transaction.go
@@ -1,0 +1,608 @@
+// OWNER: stan
+
+package endpoint
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/spolu/settle/lib/db"
+	"github.com/spolu/settle/lib/errors"
+	"github.com/spolu/settle/lib/format"
+	"github.com/spolu/settle/lib/ptr"
+	"github.com/spolu/settle/lib/svc"
+	"github.com/spolu/settle/mint"
+	"github.com/spolu/settle/mint/async"
+	"github.com/spolu/settle/mint/async/task"
+	"github.com/spolu/settle/mint/lib/authentication"
+	"github.com/spolu/settle/mint/model"
+	"goji.io/pat"
+)
+
+const (
+	// EndPtCancelTransaction cancels a reserved transaction.
+	EndPtCancelTransaction EndPtName = "CancelTransaction"
+)
+
+func init() {
+	registrar[EndPtCancelTransaction] = NewCancelTransaction
+}
+
+// CancelTransaction creates a new transaction.
+type CancelTransaction struct {
+	Client *mint.Client
+
+	// Parameters
+	Hop   int8
+	ID    string
+	Token string
+	Owner string
+
+	// State
+	Tx   *model.Transaction
+	Plan *TxPlan
+}
+
+// NewCancelTransaction constructs and initialiezes the endpoint.
+func NewCancelTransaction(
+	r *http.Request,
+) (Endpoint, error) {
+	ctx := r.Context()
+
+	client := &mint.Client{}
+	err := client.Init(ctx)
+	if err != nil {
+		return nil, errors.Trace(err) // 500
+	}
+	return &CancelTransaction{
+		Client: client,
+	}, nil
+}
+
+// Validate validates the input parameters.
+func (e *CancelTransaction) Validate(
+	r *http.Request,
+) error {
+	ctx := r.Context()
+
+	switch authentication.Get(ctx).Status {
+	case authentication.AutStSkipped:
+		// Validate hop.
+		hop, err := ValidateHop(ctx, r.PostFormValue("hop"))
+		if err != nil {
+			return errors.Trace(err)
+		}
+		e.Hop = *hop
+	}
+
+	// Validate id.
+	id, owner, token, err := ValidateID(ctx, pat.Param(r, "transaction"))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	e.ID = *id
+	e.Token = *token
+	e.Owner = *owner
+
+	return nil
+}
+
+// Execute executes the endpoint.
+func (e *CancelTransaction) Execute(
+	ctx context.Context,
+) (*int, *svc.Resp, error) {
+	switch authentication.Get(ctx).Status {
+	case authentication.AutStSkipped:
+		return e.ExecutePropagated(ctx)
+	case authentication.AutStSucceeded:
+		return e.ExecuteAuthenticated(ctx)
+	}
+	return nil, nil, errors.Trace(errors.Newf(
+		"Authentication status not expected: %s",
+		authentication.Get(ctx).Status))
+}
+
+// ExecuteAuthenticated executes the authenticated cancellation of a
+// transaction.
+func (e *CancelTransaction) ExecuteAuthenticated(
+	ctx context.Context,
+) (*int, *svc.Resp, error) {
+	ctx = db.Begin(ctx, "mint")
+	defer db.LoggedRollback(ctx)
+
+	// We load the transaction even if it has been propagated as the only node
+	// than can really trigger a cancellation is the last node of the
+	// transaction plan.
+	tx, err := model.LoadTransactionByID(ctx, e.ID)
+	if err != nil {
+		return nil, nil, errors.Trace(err) // 500
+	} else if tx == nil {
+		return nil, nil, errors.Trace(errors.NewUserErrorf(nil,
+			404, "transaction_not_found",
+			"The transaction you are trying to cancel does not "+
+				"exist: %s.", e.ID,
+		))
+	}
+	e.Tx = tx
+
+	// Transaction can be either pending or reserved.
+	switch e.Tx.Status {
+	case mint.TxStSettled:
+		return nil, nil, errors.Trace(errors.NewUserErrorf(nil,
+			402, "cancellation_failed",
+			"The transaction you are trying to cancel is settled: %s.",
+			e.ID,
+		))
+	}
+
+	plan, err := ComputePlan(ctx, e.Client, e.Tx)
+	if err != nil {
+		return nil, nil, errors.Trace(errors.NewUserErrorf(err,
+			402, "cancellation_failed",
+			"The plan computation for the transaction failed: %s", e.ID,
+		))
+	}
+	e.Plan = plan
+
+	minHop, maxHop, err := e.Plan.MinMaxHop(ctx)
+	if err != nil {
+		return nil, nil, errors.Trace(errors.NewUserErrorf(err,
+			402, "cancellation_failed",
+			"This node is not part of the transaction plan for %s", e.ID,
+		))
+	}
+	e.Hop = *maxHop
+
+	owner := fmt.Sprintf("%s@%s",
+		authentication.Get(ctx).User.Username,
+		mint.GetHost(ctx))
+
+	// Check that the requestor is the owner of the operation associated with
+	// this transaction at this hop.
+	if owner != e.Plan.Hops[e.Hop].OpAction.Owner {
+		return nil, nil, errors.Trace(errors.NewUserErrorf(err,
+			402, "cancellation_not_authorized",
+			"Only the owner of the action associated with the highest hop of "+
+				"this mint can cancel the transaction: %s",
+			e.Plan.Hops[e.Hop].OpAction.Owner,
+		))
+	}
+
+	// Check cancelation can be performed (either we're the last node, or the
+	// node after us has already canceled the transaction, or the node after us
+	// does not know about the transaction).
+	err = e.CheckCanCancel(ctx)
+	if err != nil {
+		return nil, nil, errors.Trace(errors.NewUserErrorf(err,
+			402, "cancellation_failed",
+			"This transaction has not been cancelled by the next node on the "+
+				"transaction plan: %s",
+			e.Plan.Hops[e.Hop+1].Mint,
+		))
+	}
+
+	// Cancel will idempotently cancel the transaction on all hops that are
+	// involving this mint.
+	err = e.Cancel(ctx)
+	if err != nil {
+		return nil, nil, errors.Trace(errors.NewUserErrorf(err,
+			402, "cancellation_failed",
+			"The cancellation execution failed for the transaction: %s", e.ID,
+		))
+	}
+
+	// We mark the transaction as cancelled if the hop of this is the minimal
+	// one for this mint. Cancelation checks only use operations and crossings
+	// anre the status of a transaction is mostly indicative, but we want to
+	// mark it as cancelled only after it is cancelled at all hops.
+	if e.Hop == *minHop {
+		tx.Status = mint.TxStCanceled
+		err = tx.Save(ctx)
+		if err != nil {
+			return nil, nil, errors.Trace(err) // 500
+		}
+	}
+
+	ops, err := model.LoadCanonicalOperationsByTransaction(ctx, e.ID)
+	if err != nil {
+		return nil, nil, errors.Trace(err) // 500
+	}
+
+	crs, err := model.LoadCanonicalCrossingsByTransaction(ctx, e.ID)
+	if err != nil {
+		return nil, nil, errors.Trace(err) // 500
+	}
+
+	db.Commit(ctx)
+
+	err = e.Propagate(ctx)
+	if err != nil {
+
+		// TODO(stan): async propagate in case of synchronous error instead of
+		// erroring.
+
+		return nil, nil, errors.Trace(errors.NewUserErrorf(err,
+			402, "cancelation_failed",
+			"The transaction failed to cancel on required mints: %s.",
+			e.ID,
+		))
+	}
+
+	return ptr.Int(http.StatusOK), &svc.Resp{
+		"transaction": format.JSONPtr(model.NewTransactionResource(ctx,
+			tx, ops, crs,
+		)),
+	}, nil
+}
+
+// ExecutePropagated executes the settlement of a propagated transaction
+// (involved mint).
+func (e *CancelTransaction) ExecutePropagated(
+	ctx context.Context,
+) (*int, *svc.Resp, error) {
+	ctx = db.Begin(ctx, "mint")
+	defer db.LoggedRollback(ctx)
+
+	tx, err := model.LoadTransactionByID(ctx, e.ID)
+	if err != nil {
+		return nil, nil, errors.Trace(err) // 500
+	}
+	if tx != nil {
+		e.Tx = tx
+	} else {
+		tx, err := model.LoadPropagatedTransactionByOwnerToken(ctx,
+			e.Owner, e.Token)
+		if err != nil {
+			return nil, nil, errors.Trace(err) // 500
+		} else if tx == nil {
+			return nil, nil, errors.Trace(errors.NewUserErrorf(nil,
+				404, "transaction_not_found",
+				"The transaction you are trying to settle does not "+
+					"exist: %s.", e.ID,
+			))
+		}
+		e.Tx = tx
+	}
+
+	// Transaction can be either pending, reserved or already canceled.
+	switch e.Tx.Status {
+	case mint.TxStSettled:
+		return nil, nil, errors.Trace(errors.NewUserErrorf(nil,
+			402, "cancellation_failed",
+			"The transaction you are trying to cancel is settled: %s.",
+			e.ID,
+		))
+	}
+
+	plan, err := ComputePlan(ctx, e.Client, e.Tx)
+	if err != nil {
+		return nil, nil, errors.Trace(errors.NewUserErrorf(err,
+			402, "settlement_failed",
+			"The plan computation for the transaction failed: %s", e.ID,
+		))
+	}
+	e.Plan = plan
+
+	minHop, _, err := e.Plan.MinMaxHop(ctx)
+	if err != nil {
+		return nil, nil, errors.Trace(errors.NewUserErrorf(err,
+			402, "cancellation_failed",
+			"This node is not part of the transaction plan for %s", e.ID,
+		))
+	}
+
+	if int(e.Hop) >= len(e.Plan.Hops) ||
+		e.Plan.Hops[e.Hop].Mint != mint.GetHost(ctx) {
+		return nil, nil, errors.Trace(errors.NewUserErrorf(nil,
+			402, "settlement_failed",
+			"The hop provided (%d) does not match the current mint (%s) for "+
+				"transaction: %s", e.Hop, mint.GetHost(ctx), e.ID,
+		))
+	}
+
+	// Check cancelation can be performed (either we're the last node, or the
+	// node after us has already canceled the transaction, or the node after us
+	// does not know about the transaction).
+	err = e.CheckCanCancel(ctx)
+	if err != nil {
+		return nil, nil, errors.Trace(errors.NewUserErrorf(err,
+			402, "cancellation_failed",
+			"This transaction has not been cancelled by the next node on the "+
+				"transaction plan: %s",
+			e.Plan.Hops[e.Hop+1].Mint,
+		))
+	}
+
+	// Cancel will idempotently cancel the transaction on all hops that are
+	// involving this mint.
+	err = e.Cancel(ctx)
+	if err != nil {
+		return nil, nil, errors.Trace(errors.NewUserErrorf(err,
+			402, "cancellation_failed",
+			"The cancellation execution failed for the transaction: %s", e.ID,
+		))
+	}
+
+	// We mark the transaction as cancelled if the hop of this is the minimal
+	// one for this mint. Cancelation checks only use operations and crossings
+	// anre the status of a transaction is mostly indicative, but we want to
+	// mark it as cancelled only after it is cancelled at all hops.
+	if e.Hop == *minHop {
+		tx.Status = mint.TxStCanceled
+		err = tx.Save(ctx)
+		if err != nil {
+			return nil, nil, errors.Trace(err) // 500
+		}
+	}
+
+	ops, err := model.LoadCanonicalOperationsByTransaction(ctx, e.ID)
+	if err != nil {
+		return nil, nil, errors.Trace(err) // 500
+	}
+
+	crs, err := model.LoadCanonicalCrossingsByTransaction(ctx, e.ID)
+	if err != nil {
+		return nil, nil, errors.Trace(err) // 500
+	}
+
+	// Commit the transaction as well as operations and crossings as settled.
+	db.Commit(ctx)
+
+	err = e.Propagate(ctx)
+	if err != nil {
+
+		// TODO(stan): async propagate in case of synchronous error
+
+		return nil, nil, errors.Trace(errors.NewUserErrorf(err,
+			402, "settlement_failed",
+			"The transaction failed to settle on required mints: %s.",
+			e.ID,
+		))
+	}
+
+	return ptr.Int(http.StatusOK), &svc.Resp{
+		"transaction": format.JSONPtr(model.NewTransactionResource(ctx,
+			tx, ops, crs,
+		)),
+	}, nil
+}
+
+// Cancel cancels idempotently the underlying operations and crossings at the
+// current hop.
+func (e *CancelTransaction) Cancel(
+	ctx context.Context,
+) error {
+	if int(e.Hop) >= len(e.Plan.Hops) {
+		return errors.Trace(errors.Newf(
+			"Hop (%d) is higher than the transaction plan length (%d)",
+			e.Hop, len(e.Plan.Hops)))
+	}
+
+	h := e.Plan.Hops[e.Hop]
+	mint.Logf(ctx,
+		"Executing cancellation plan: transaction=%s hop=%d", e.ID, e.Hop)
+
+	// Cancel the OpAction (should always be defined)
+	if h.OpAction != nil {
+		op, err := model.LoadCanonicalOperationByTransactionHop(ctx,
+			e.ID, e.Hop)
+		if err != nil {
+			return errors.Trace(err)
+		} else if op == nil {
+			return errors.Trace(errors.Newf(
+				"Operation not found for transaction %s and hop %d",
+				e.ID, h))
+		}
+
+		if op.Status == mint.TxStCanceled {
+			mint.Logf(ctx,
+				"Skipped operation: id=%s[%s] created=%q propagation=%s "+
+					"asset=%s source=%s destination=%s amount=%s "+
+					"status=%s transaction=%s",
+				op.Owner, op.Token, op.Created, op.Propagation, op.Asset,
+				op.Source, op.Destination, (*big.Int)(&op.Amount).String(),
+				op.Status, *op.Transaction)
+
+		} else {
+			a := h.OpAction
+
+			asset, err := model.LoadCanonicalAssetByName(ctx, *a.OperationAsset)
+			if err != nil {
+				return errors.Trace(err)
+			} else if asset == nil {
+				return errors.Trace(errors.Newf(
+					"Asset not found: %s", *a.OperationAsset))
+			}
+
+			// Restore the source balance if applicable (that is if the op
+			// source is not owner of the asset, in which case the asset was
+			// issued on the fly).
+			var srcBalance *model.Balance
+			if asset.Owner != op.Source {
+				srcBalance, err = model.LoadCanonicalBalanceByAssetHolder(ctx,
+					op.Asset, op.Source)
+				if err != nil {
+					return errors.Trace(err)
+				} else if srcBalance == nil {
+					return errors.Trace(errors.Newf(
+						"Source has no balance in %s: %s", op.Asset, op.Source))
+				}
+				(*big.Int)(&srcBalance.Value).Add(
+					(*big.Int)(&srcBalance.Value), (*big.Int)(&op.Amount))
+
+				// Checks if the srcBalance is positive and not overflown.
+				b := (*big.Int)(&srcBalance.Value)
+				if new(big.Int).Abs(b).Cmp(model.MaxAssetAmount) >= 0 ||
+					b.Cmp(new(big.Int)) < 0 {
+					return errors.Trace(errors.Newf(
+						"Invalid resulting balance for %s: %s",
+						srcBalance.Holder, b.String()))
+				}
+
+				err = srcBalance.Save(ctx)
+				if err != nil {
+					return errors.Trace(err)
+				}
+
+				err = async.Queue(ctx,
+					task.NewPropagateBalance(ctx, time.Now(), srcBalance.ID()))
+				if err != nil {
+					return errors.Trace(err)
+				}
+			}
+
+			op.Status = mint.TxStCanceled
+			err = op.Save(ctx)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			mint.Logf(ctx,
+				"Canceled operation: id=%s[%s] created=%q propagation=%s "+
+					"asset=%s source=%s destination=%s amount=%s "+
+					"status=%s transaction=%s",
+				op.Owner, op.Token, op.Created, op.Propagation, op.Asset,
+				op.Source, op.Destination, (*big.Int)(&op.Amount).String(),
+				op.Status, *op.Transaction)
+		}
+	}
+
+	if h.CrAction != nil {
+		cr, err := model.LoadCanonicalCrossingByTransactionHop(ctx,
+			e.ID, e.Hop)
+		if err != nil {
+			return errors.Trace(err)
+		} else if cr == nil {
+			return errors.Trace(errors.Newf(
+				"Crossing not found for transaction %s and hop %d",
+				e.ID, h))
+		}
+
+		if cr.Status == mint.TxStSettled {
+			mint.Logf(ctx,
+				"Skipped crossing: id=%s[%s] created=%q offer=%s amount=%s "+
+					"status=%s transaction=%s",
+				cr.Owner, cr.Token, cr.Created, cr.Offer,
+				(*big.Int)(&cr.Amount).String(), cr.Status, cr.Transaction)
+		} else {
+			a := h.CrAction
+
+			offer, err := model.LoadCanonicalOfferByID(ctx, *a.CrossingOffer)
+			if err != nil {
+				return errors.Trace(err)
+			} else if offer == nil {
+				return errors.Trace(errors.Newf(
+					"Offer not found: %s", *a.CrossingOffer))
+			}
+
+			(*big.Int)(&offer.Remainder).Add(
+				(*big.Int)(&offer.Remainder), (*big.Int)(&cr.Amount))
+
+			// Checks if the remainder is positive and not overflown.
+			b := (*big.Int)(&offer.Remainder)
+			if new(big.Int).Abs(b).Cmp(model.MaxAssetAmount) >= 0 ||
+				b.Cmp(new(big.Int)) < 0 {
+				return errors.Trace(errors.Newf(
+					"Invalid resulting remainder: %s", b.String()))
+			}
+			// Set the offer as active if the remainder is not 0 and the offer
+			// is not closed.
+			if offer.Status != mint.OfStClosed && b.Cmp(new(big.Int)) > 0 {
+				offer.Status = mint.OfStActive
+			}
+
+			err = offer.Save(ctx)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			err = async.Queue(ctx,
+				task.NewPropagateOffer(ctx, time.Now(), offer.ID()))
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			cr.Status = mint.TxStCanceled
+			err = cr.Save(ctx)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			mint.Logf(ctx,
+				"Canceled crossing: id=%s[%s] created=%q offer=%s amount=%s "+
+					"status=%s transaction=%s",
+				cr.Owner, cr.Token, cr.Created, cr.Offer,
+				(*big.Int)(&cr.Amount).String(), cr.Status, cr.Transaction)
+		}
+	}
+
+	return nil
+}
+
+// Propagate the transaction cancellation. Current hop cancellation is already
+// performed.
+func (e *CancelTransaction) Propagate(
+	ctx context.Context,
+) error {
+	if int(e.Hop)-1 >= 0 {
+		m := e.Plan.Hops[e.Hop-1].Mint
+
+		mint.Logf(ctx,
+			"Propagating cancellation: transaction=%s hop=%d mint=%s",
+			e.ID, e.Hop, m)
+
+		hop := e.Hop - 1
+		_, err := e.Client.CancelTransaction(ctx, e.ID, hop, m)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	return nil
+}
+
+// CheckCanCancel checks that this node is authorized to cancel the transaction
+// (this is the node with higher hop or the node above it has already canceled
+// the transaction).
+func (e *CancelTransaction) CheckCanCancel(
+	ctx context.Context,
+) error {
+	if e.Hop == int8(len(e.Plan.Hops)-1) {
+		return nil
+	}
+
+	txn, err := e.Client.RetrieveTransaction(ctx,
+		e.ID, &e.Plan.Hops[e.Hop+1].Mint)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// TODO(stan): add support for 404
+
+	operation := (*mint.OperationResource)(nil)
+	for _, op := range txn.Operations {
+		op := op
+		if op.TransactionHop != nil && *op.TransactionHop == e.Hop+1 {
+			operation = &op
+		}
+	}
+	if operation != nil && operation.Status != mint.TxStCanceled {
+		return errors.Newf("Mint at next hop has not canceled the transaction")
+	}
+
+	crossing := (*mint.CrossingResource)(nil)
+	for _, cr := range txn.Crossings {
+		cr := cr
+		if cr.TransactionHop == e.Hop+1 {
+			crossing = &cr
+		}
+	}
+	if crossing != nil && crossing.Status != mint.TxStCanceled {
+		return errors.Newf("Mint at next hop has not canceled the transaction")
+	}
+
+	return nil
+}

--- a/mint/endpoint/create_transaction.go
+++ b/mint/endpoint/create_transaction.go
@@ -507,7 +507,7 @@ func (e *CreateTransaction) ExecutePlan(
 			}
 
 			op, err := model.CreateCanonicalOperation(ctx,
-				asset.Owner,
+				a.Owner,
 				*a.OperationAsset,
 				*a.OperationSource,
 				*a.OperationDestination,
@@ -594,8 +594,7 @@ func (e *CreateTransaction) ExecutePlan(
 		} else {
 			a := h.CrAction
 
-			offer, err := model.LoadCanonicalOfferByID(ctx,
-				*a.CrossingOffer)
+			offer, err := model.LoadCanonicalOfferByID(ctx, *a.CrossingOffer)
 			if err != nil {
 				return errors.Trace(err)
 			} else if offer == nil {
@@ -609,7 +608,7 @@ func (e *CreateTransaction) ExecutePlan(
 			}
 
 			cr, err := model.CreateCanonicalCrossing(ctx,
-				offer.Owner,
+				a.Owner,
 				*a.CrossingOffer,
 				model.Amount(*a.Amount),
 				mint.TxStReserved,

--- a/mint/endpoint/transaction_plan.go
+++ b/mint/endpoint/transaction_plan.go
@@ -320,3 +320,25 @@ func (p *TxPlan) Check(
 
 	return nil
 }
+
+// MinMaxHop returns the lowest and highest hops for the local mint in the
+// transaction plan.
+func (p *TxPlan) MinMaxHop(
+	ctx context.Context,
+) (*int8, *int8, error) {
+	min := int8(-1)
+	max := int8(-1)
+	for i, h := range p.Hops {
+		if h.Mint == mint.GetHost(ctx) {
+			max = int8(i)
+			if min == -1 {
+				min = int8(i)
+			}
+		}
+	}
+	if max == -1 {
+		return nil, nil, errors.Newf(
+			"This mint is not part of the transction plan.")
+	}
+	return &min, &max, nil
+}

--- a/mint/model/operation.go
+++ b/mint/model/operation.go
@@ -27,9 +27,9 @@ var MaxAssetAmount = new(big.Int).Exp(
 // - Canonical operations are stored on the mint of the operation's owner
 //   (which acts as source of truth on its state).
 // - Propagated operations are stored on the mints of the operation's source or
-//   destination, for retrieval by impacted users.
+//   destination, for retrieval by impacted users (only settled operations are
+//   reserved).
 // - When part of a transaction, an operation refers the transaction and hop.
-// - Only settled operation are propagated.
 type Operation struct {
 	Owner       string // Owner address.
 	Token       string

--- a/mint/protocol.go
+++ b/mint/protocol.go
@@ -11,9 +11,6 @@ const (
 	// TransactionExpiryMs is the time it takes to expire a transaction for
 	// this mint (get it canceled if not settled). Expressed in ms.
 	TransactionExpiryMs int64 = 1000 * 60 * 60
-	// TransactionExpiryBufferMs is the minimal acceptable duration between a
-	// transaction expiry and its creation time.
-	TransactionExpiryBufferMs int64 = 1000 * 60
 )
 
 // PgType is the propagation type of an object.


### PR DESCRIPTION
Introduce transaction cancellation.

A mint can only cancel a transaction if it's not yet settled and the mint after it on the offer path has cancelled the transaction (such that no trust relationship is broken). As such only the receiving user can cancel a transaction.