### PR TITLE
Remote asset and cancelation tests and fixes

### DIFF
--- a/TODO
+++ b/TODO
@@ -117,12 +117,13 @@
       [ ] B fails reservation entirely
       [ ] B pass reservation through but fails responding to C
       [ ] A settles to C who fails
-    [ ] test same mint multiple uers
+    [ ] test same mint multiple users
     [ ] test cycles in offer path
     [ ] offer closing + attempt transaction on it
     [ ] offer closing of an offer not owned by caller
     [ ] test that consumes an offer entirely (check status)
     [~] transaction tests with misbehaving mint
+    [x] test transaction cancellation
     [x] test asset retrieval
     [x] test settling an expired transaction
     [x] transaction expiration and balance fixup

--- a/mint/app/controller.go
+++ b/mint/app/controller.go
@@ -26,6 +26,7 @@ func (c *Controller) Bind(
 
 	// Mixed.
 	mux.HandleFunc(pat.Post("/transactions/:transaction/settle"), endpoint.HandlerFor(endpoint.EndPtSettleTransaction))
+	mux.HandleFunc(pat.Post("/transactions/:transaction/cancel"), endpoint.HandlerFor(endpoint.EndPtCancelTransaction))
 
 	// Public.
 	mux.HandleFunc(pat.Get("/offers/:offer"), endpoint.HandlerFor(endpoint.EndPtRetrieveOffer))

--- a/mint/endpoint/cancel_transaction.go
+++ b/mint/endpoint/cancel_transaction.go
@@ -160,9 +160,9 @@ func (e *CancelTransaction) ExecuteAuthenticated(
 		authentication.Get(ctx).User.Username,
 		mint.GetHost(ctx))
 
-	// Check that the requestor is the owner of the operation associated with
-	// this transaction at this hop.
-	if owner != e.Plan.Hops[e.Hop].OpAction.Owner {
+	// Check that the requestor is the owner of the transaction or the
+	// operation associated with the transaction at this hop.
+	if owner != e.Tx.Owner && owner != e.Plan.Hops[e.Hop].OpAction.Owner {
 		return nil, nil, errors.Trace(errors.NewUserErrorf(err,
 			402, "cancellation_not_authorized",
 			"Only the owner of the action associated with the highest hop of "+

--- a/mint/endpoint/propagate_offer.go
+++ b/mint/endpoint/propagate_offer.go
@@ -195,8 +195,6 @@ func (e *PropagateOffer) Execute(
 		of.Status = offer.Status
 		of.Remainder = model.Amount(*remainder)
 
-		// TODO(stan): check that the rest offer hasn't changed.
-
 		err := of.Save(ctx)
 		if err != nil {
 			return nil, nil, errors.Trace(err) // 500

--- a/mint/endpoint/propagate_operation.go
+++ b/mint/endpoint/propagate_operation.go
@@ -193,8 +193,6 @@ func (e *PropagateOperation) ExecutePropagated(
 		return nil, nil, errors.Trace(err) // 500
 	} else if op != nil {
 		// Nothing to do: an operation is immutable once settled.
-		// TODO(stan): check that the operation hasn't changed.
-
 		code = http.StatusOK
 	} else {
 		// Create propagated operation locally.

--- a/mint/lib/authentication/middleware.go
+++ b/mint/lib/authentication/middleware.go
@@ -77,6 +77,7 @@ var SkipList = []*SkipRule{
 
 	&SkipRule{"POST", regexp.MustCompile("^/transactions/[a-zA-Z0-9_\\+:@\\.\\[\\]]+$")},
 	&SkipRule{"POST", regexp.MustCompile("^/transactions/[a-zA-Z0-9_\\+:@\\.\\[\\]]+/settle$")},
+	&SkipRule{"POST", regexp.MustCompile("^/transactions/[a-zA-Z0-9_\\+:@\\.\\[\\]]+/cancel$")},
 
 	&SkipRule{"GET", regexp.MustCompile("^/assets/[a-zA-Z0-9_\\+:@\\.\\[\\]]+$")},
 	&SkipRule{"GET", regexp.MustCompile("^/assets/[a-zA-Z0-9_\\+:@\\.\\[\\]]+/offers$")},

--- a/mint/test/functional/cancel_transaction_test.go
+++ b/mint/test/functional/cancel_transaction_test.go
@@ -6,14 +6,13 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/spolu/settle/lib/errors"
 	"github.com/spolu/settle/mint"
 	"github.com/spolu/settle/mint/model"
 	"github.com/spolu/settle/mint/test"
 	"github.com/stretchr/testify/assert"
 )
 
-func setupSettleTransaction(
+func setupCancelTransaction(
 	t *testing.T,
 ) ([]*test.Mint, []*test.MintUser, []mint.AssetResource, []mint.OfferResource) {
 	m := []*test.Mint{
@@ -47,7 +46,7 @@ func setupSettleTransaction(
 	return m, u, a, o
 }
 
-func tearDownSettleTransaction(
+func tearDownCancelTransaction(
 	t *testing.T,
 	mints []*test.Mint,
 ) {
@@ -56,12 +55,12 @@ func tearDownSettleTransaction(
 	}
 }
 
-func TestSettleTransactionWith2Offers(
+func TestCancelTransactionWith2Offers(
 	t *testing.T,
 ) {
 	t.Parallel()
-	m, u, a, o := setupSettleTransaction(t)
-	defer tearDownSettleTransaction(t, m)
+	m, u, a, o := setupCancelTransaction(t)
+	defer tearDownCancelTransaction(t, m)
 
 	status, raw := u[0].Post(t,
 		fmt.Sprintf("/transactions"),
@@ -81,117 +80,84 @@ func TestSettleTransactionWith2Offers(
 	err := raw.Extract("transaction", &tx)
 	assert.Nil(t, err)
 
-	status, raw = u[0].Post(t,
-		fmt.Sprintf("/transactions/%s/settle", tx.ID),
+	status, raw = u[2].Post(t,
+		fmt.Sprintf("/transactions/%s/cancel", tx.ID),
 		url.Values{})
-
-	var tx0 mint.TransactionResource
-	err = raw.Extract("transaction", &tx0)
-	assert.Nil(t, err)
-
-	assert.Equal(t, 200, status)
-	assert.Equal(t, mint.TxStSettled, tx0.Status)
-	assert.Equal(t, 1, len(tx0.Operations))
-	assert.Equal(t, []mint.CrossingResource{}, tx0.Crossings)
-
-	assert.Equal(t, mint.TxStSettled, tx0.Operations[0].Status)
-
-	// Check transaction on m[1].
-	status, raw = u[1].Get(t, fmt.Sprintf("/transactions/%s", tx0.ID))
-
-	var tx1 mint.TransactionResource
-	err = raw.Extract("transaction", &tx1)
-	assert.Nil(t, err)
-
-	assert.Equal(t, 200, status)
-	assert.Equal(t, mint.TxStSettled, tx1.Status)
-	assert.Equal(t, 1, len(tx1.Operations))
-	assert.Equal(t, 1, len(tx1.Crossings))
-
-	assert.Equal(t, mint.TxStSettled, tx1.Crossings[0].Status)
-	assert.Equal(t, mint.TxStSettled, tx1.Operations[0].Status)
-
-	// Check transaction on m[2].
-	status, raw = u[2].Get(t, fmt.Sprintf("/transactions/%s", tx0.ID))
 
 	var tx2 mint.TransactionResource
 	err = raw.Extract("transaction", &tx2)
 	assert.Nil(t, err)
 
 	assert.Equal(t, 200, status)
-	assert.Equal(t, mint.TxStSettled, tx2.Status)
+	assert.Equal(t, mint.TxStCanceled, tx2.Status)
 	assert.Equal(t, 1, len(tx2.Operations))
 	assert.Equal(t, 1, len(tx2.Crossings))
 
-	assert.Equal(t, mint.TxStSettled, tx2.Crossings[0].Status)
-	assert.Equal(t, mint.TxStSettled, tx2.Operations[0].Status)
+	assert.Equal(t, mint.TxStCanceled, tx2.Crossings[0].Status)
+	assert.Equal(t, mint.TxStCanceled, tx2.Operations[0].Status)
+
+	// Check transaction on m[1].
+	status, raw = u[1].Get(t, fmt.Sprintf("/transactions/%s", tx.ID))
+
+	var tx1 mint.TransactionResource
+	err = raw.Extract("transaction", &tx1)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 200, status)
+	assert.Equal(t, mint.TxStCanceled, tx1.Status)
+	assert.Equal(t, 1, len(tx1.Operations))
+	assert.Equal(t, 1, len(tx1.Crossings))
+
+	assert.Equal(t, mint.TxStCanceled, tx1.Crossings[0].Status)
+	assert.Equal(t, mint.TxStCanceled, tx1.Operations[0].Status)
+
+	// Check transaction on m[0].
+	status, raw = u[0].Get(t, fmt.Sprintf("/transactions/%s", tx.ID))
+
+	var tx0 mint.TransactionResource
+	err = raw.Extract("transaction", &tx0)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 200, status)
+	assert.Equal(t, mint.TxStCanceled, tx0.Status)
+	assert.Equal(t, 0, len(tx0.Crossings))
+	assert.Equal(t, 1, len(tx0.Operations))
+
+	assert.Equal(t, mint.TxStCanceled, tx0.Operations[0].Status)
 
 	// Check balance on m[0]
 	balance, err := model.LoadCanonicalBalanceByAssetHolder(m[0].Ctx,
 		a[0].Name, u[1].Address)
 	assert.Nil(t, err)
-	assert.Equal(t, big.NewInt(11), (*big.Int)(&balance.Value))
+	assert.Equal(t, big.NewInt(0), (*big.Int)(&balance.Value))
 
 	// Check balance on m[1]
 	balance, err = model.LoadCanonicalBalanceByAssetHolder(m[1].Ctx,
 		a[1].Name, u[2].Address)
 	assert.Nil(t, err)
-	assert.Equal(t, big.NewInt(11), (*big.Int)(&balance.Value))
+	assert.Equal(t, big.NewInt(0), (*big.Int)(&balance.Value))
 
-	// Check that re-settling does not trigger an error.
+	// Check that re-canceling does not trigger an error.
+	status, _ = u[2].Post(t,
+		fmt.Sprintf("/transactions/%s/cancel", tx.ID),
+		url.Values{})
+
+	assert.Equal(t, 200, status)
+
+	// Check that settling does  trigger an error.
 	status, _ = u[0].Post(t,
 		fmt.Sprintf("/transactions/%s/settle", tx.ID),
 		url.Values{})
 
-	assert.Equal(t, 200, status)
+	assert.Equal(t, 402, status)
 }
 
-func TestSettleTransactionWithWrongSecret(
+func TestCancelTransactionmWithNoOffer(
 	t *testing.T,
 ) {
 	t.Parallel()
-	m, u, a, o := setupSettleTransaction(t)
-	defer tearDownSettleTransaction(t, m)
-
-	status, raw := u[0].Post(t,
-		fmt.Sprintf("/transactions"),
-		url.Values{
-			"pair":        {fmt.Sprintf("%s/%s", a[0].Name, a[2].Name)},
-			"amount":      {"10"},
-			"destination": {u[2].Address},
-			"path[]": {
-				o[1].ID,
-				o[2].ID,
-			},
-		})
-
-	assert.Equal(t, 201, status)
-
-	var tx mint.TransactionResource
-	err := raw.Extract("transaction", &tx)
-	assert.Nil(t, err)
-
-	status, raw = m[1].Post(t, nil,
-		fmt.Sprintf("/transactions/%s/settle", tx.ID),
-		url.Values{
-			"hop":    {"1"},
-			"secret": {"foo"},
-		})
-
-	var e errors.ConcreteUserError
-	err = raw.Extract("error", &e)
-	assert.Nil(t, err)
-
-	assert.Equal(t, 400, status)
-	assert.Equal(t, "secret_invalid", e.ErrCode)
-}
-
-func TestSettleTransactionmWithNoOffer(
-	t *testing.T,
-) {
-	t.Parallel()
-	m, u, a, _ := setupSettleTransaction(t)
-	defer tearDownSettleTransaction(t, m)
+	m, u, a, _ := setupCancelTransaction(t)
+	defer tearDownCancelTransaction(t, m)
 
 	status, raw := u[0].Post(t,
 		fmt.Sprintf("/transactions"),
@@ -208,7 +174,7 @@ func TestSettleTransactionmWithNoOffer(
 	assert.Nil(t, err)
 
 	status, raw = u[0].Post(t,
-		fmt.Sprintf("/transactions/%s/settle", tx.ID),
+		fmt.Sprintf("/transactions/%s/cancel", tx.ID),
 		url.Values{})
 
 	var tx0 mint.TransactionResource
@@ -216,13 +182,14 @@ func TestSettleTransactionmWithNoOffer(
 	assert.Nil(t, err)
 
 	assert.Equal(t, 200, status)
+	assert.Equal(t, mint.TxStCanceled, tx0.Status)
 	assert.Equal(t, 0, len(tx0.Crossings))
 	assert.Equal(t, 1, len(tx0.Operations))
 
 	assert.Equal(t, u[0].Address, tx0.Operations[0].Source)
 	assert.Equal(t, u[1].Address, tx0.Operations[0].Destination)
 	assert.Equal(t, big.NewInt(10), tx0.Operations[0].Amount)
-	assert.Equal(t, mint.TxStSettled, tx0.Operations[0].Status)
+	assert.Equal(t, mint.TxStCanceled, tx0.Operations[0].Status)
 	assert.Equal(t, tx.ID, *tx0.Operations[0].Transaction)
 	assert.Equal(t, int8(0), *tx0.Operations[0].TransactionHop)
 
@@ -230,10 +197,10 @@ func TestSettleTransactionmWithNoOffer(
 	balance, err := model.LoadCanonicalBalanceByAssetHolder(m[0].Ctx,
 		a[0].Name, u[1].Address)
 	assert.Nil(t, err)
-	assert.Equal(t, big.NewInt(10), (*big.Int)(&balance.Value))
+	assert.Equal(t, big.NewInt(0), (*big.Int)(&balance.Value))
 }
 
-func TestSettleTransactionWithRemoteBaseAsset(
+func TestCancelTransactionWithRemoteBaseAsset(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -277,20 +244,33 @@ func TestSettleTransactionWithRemoteBaseAsset(
 	err = raw.Extract("transaction", &tx0)
 	assert.Nil(t, err)
 
+	// Check that cancelation can't happen on m[0] and m[1].
 	status, raw = u[0].Post(t,
-		fmt.Sprintf("/transactions/%s/settle", tx0.ID),
+		fmt.Sprintf("/transactions/%s/cancel", tx0.ID),
+		url.Values{})
+	assert.Equal(t, 402, status)
+	status, raw = u[1].Post(t,
+		fmt.Sprintf("/transactions/%s/cancel", tx0.ID),
+		url.Values{})
+	assert.Equal(t, 402, status)
+
+	status, raw = u[2].Post(t,
+		fmt.Sprintf("/transactions/%s/cancel", tx0.ID),
 		url.Values{})
 
 	assert.Equal(t, 200, status)
 
-	err = raw.Extract("transaction", &tx0)
+	var tx2 mint.TransactionResource
+	err = raw.Extract("transaction", &tx2)
 	assert.Nil(t, err)
 
-	// Check transaction from m[0].
-	assert.Regexp(t, mint.IDRegexp, tx0.ID)
-	assert.Equal(t, mint.TxStSettled, tx0.Status)
-	assert.Equal(t, 0, len(tx0.Operations))
-	assert.Equal(t, 0, len(tx0.Crossings))
+	// Check transaction from m[2].
+	assert.Equal(t, mint.TxStCanceled, tx2.Status)
+	assert.Equal(t, 1, len(tx2.Crossings))
+	assert.Equal(t, 1, len(tx2.Operations))
+
+	assert.Equal(t, mint.TxStCanceled, tx2.Crossings[0].Status)
+	assert.Equal(t, mint.TxStCanceled, tx2.Operations[0].Status)
 
 	// Check transaction on m[1].
 	status, raw = m[1].Get(t, nil, fmt.Sprintf("/transactions/%s", tx0.ID))
@@ -300,40 +280,36 @@ func TestSettleTransactionWithRemoteBaseAsset(
 	assert.Nil(t, err)
 
 	assert.Equal(t, 200, status)
-	assert.Equal(t, mint.TxStSettled, tx1.Status)
+	assert.Equal(t, mint.TxStCanceled, tx1.Status)
 	assert.Equal(t, 0, len(tx1.Crossings))
 	assert.Equal(t, 1, len(tx1.Operations))
 
-	assert.Equal(t, mint.TxStSettled, tx1.Operations[0].Status)
+	assert.Equal(t, mint.TxStCanceled, tx1.Operations[0].Status)
 
-	// Check transaction on m[2].
-	status, raw = m[2].Get(t, nil, fmt.Sprintf("/transactions/%s", tx0.ID))
+	// Check transaction on m[0].
+	status, raw = m[0].Get(t, nil, fmt.Sprintf("/transactions/%s", tx0.ID))
 
-	var tx2 mint.TransactionResource
-	err = raw.Extract("transaction", &tx2)
+	err = raw.Extract("transaction", &tx0)
 	assert.Nil(t, err)
 
-	assert.Equal(t, 200, status)
-	assert.Equal(t, mint.TxStSettled, tx2.Status)
-	assert.Equal(t, 1, len(tx2.Crossings))
-	assert.Equal(t, 1, len(tx2.Operations))
-
-	assert.Equal(t, mint.TxStSettled, tx2.Crossings[0].Status)
-	assert.Equal(t, mint.TxStSettled, tx2.Operations[0].Status)
+	assert.Regexp(t, mint.IDRegexp, tx0.ID)
+	assert.Equal(t, mint.TxStCanceled, tx0.Status)
+	assert.Equal(t, 0, len(tx0.Operations))
+	assert.Equal(t, 0, len(tx0.Crossings))
 
 	// Check balance on m[1]
 	balance, err := model.LoadCanonicalBalanceByAssetHolder(m[1].Ctx,
 		a[1].Name, u[0].Address)
 	assert.Nil(t, err)
-	assert.Equal(t, big.NewInt(0), (*big.Int)(&balance.Value))
+	assert.Equal(t, big.NewInt(11), (*big.Int)(&balance.Value))
 
 	balance, err = model.LoadCanonicalBalanceByAssetHolder(m[1].Ctx,
 		a[1].Name, u[2].Address)
 	assert.Nil(t, err)
-	assert.Equal(t, big.NewInt(11), (*big.Int)(&balance.Value))
+	assert.Equal(t, big.NewInt(0), (*big.Int)(&balance.Value))
 }
 
-func TestSettleTransactionWithNoOfferAndRemoteBaseAsset(
+func TestCancelTransactionWithNoOfferAndRemoteBaseAsset(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -381,9 +357,26 @@ func TestSettleTransactionWithNoOfferAndRemoteBaseAsset(
 	err = raw.Extract("transaction", &tx0)
 	assert.Nil(t, err)
 
-	status, raw = u[0].Post(t,
-		fmt.Sprintf("/transactions/%s/settle", tx0.ID),
+	status, raw = u[1].Post(t,
+		fmt.Sprintf("/transactions/%s/cancel", tx0.ID),
 		url.Values{})
+
+	var tx1 mint.TransactionResource
+	err = raw.Extract("transaction", &tx1)
+	assert.Nil(t, err)
+
+	assert.Regexp(t, mint.IDRegexp, tx1.ID)
+	assert.Equal(t, mint.TxStCanceled, tx1.Status)
+	assert.Equal(t, 1, len(tx1.Operations))
+	assert.Equal(t, 0, len(tx1.Crossings))
+
+	assert.Equal(t, mint.TxStCanceled, tx1.Operations[0].Status)
+	assert.Equal(t, big.NewInt(5), tx1.Operations[0].Amount)
+	assert.Equal(t, u[2].Address, tx1.Operations[0].Destination)
+	assert.Equal(t, u[0].Address, tx1.Operations[0].Source)
+
+	// Check transaction on m[0].
+	status, raw = u[0].Get(t, fmt.Sprintf("/transactions/%s", tx1.ID))
 
 	assert.Equal(t, 200, status)
 
@@ -391,37 +384,18 @@ func TestSettleTransactionWithNoOfferAndRemoteBaseAsset(
 	assert.Nil(t, err)
 
 	assert.Regexp(t, mint.IDRegexp, tx0.ID)
-	assert.Equal(t, mint.TxStSettled, tx0.Status)
+	assert.Equal(t, mint.TxStCanceled, tx0.Status)
 	assert.Equal(t, 0, len(tx0.Operations))
 	assert.Equal(t, 0, len(tx0.Crossings))
-
-	// Check transaction on m[1].
-	status, raw = u[1].Get(t, fmt.Sprintf("/transactions/%s", tx0.ID))
-
-	assert.Equal(t, 200, status)
-
-	var tx1 mint.TransactionResource
-	err = raw.Extract("transaction", &tx1)
-	assert.Nil(t, err)
-
-	assert.Regexp(t, mint.IDRegexp, tx1.ID)
-	assert.Equal(t, mint.TxStSettled, tx1.Status)
-	assert.Equal(t, 1, len(tx1.Operations))
-	assert.Equal(t, 0, len(tx1.Crossings))
-
-	assert.Equal(t, mint.TxStSettled, tx1.Operations[0].Status)
-	assert.Equal(t, big.NewInt(5), tx1.Operations[0].Amount)
-	assert.Equal(t, u[2].Address, tx1.Operations[0].Destination)
-	assert.Equal(t, u[0].Address, tx1.Operations[0].Source)
 
 	// Check balance on m[1]
 	balance, err := model.LoadCanonicalBalanceByAssetHolder(m[1].Ctx,
 		a[1].Name, u[0].Address)
 	assert.Nil(t, err)
-	assert.Equal(t, big.NewInt(5), (*big.Int)(&balance.Value))
+	assert.Equal(t, big.NewInt(10), (*big.Int)(&balance.Value))
 
 	balance, err = model.LoadCanonicalBalanceByAssetHolder(m[1].Ctx,
 		a[1].Name, u[2].Address)
 	assert.Nil(t, err)
-	assert.Equal(t, big.NewInt(5), (*big.Int)(&balance.Value))
+	assert.Equal(t, big.NewInt(0), (*big.Int)(&balance.Value))
 }


### PR DESCRIPTION
Fixes support for transaction of remote asset (transactions whose base asset is not owned by the transaction owner). Fixes a few cancellation related bug and adds tests for cancellations.