### PR TITLE
Ability to close an offer

### DIFF
--- a/cli/command/close.go
+++ b/cli/command/close.go
@@ -1,0 +1,143 @@
+package command
+
+import (
+	"context"
+
+	"github.com/spolu/settle/cli"
+	"github.com/spolu/settle/lib/errors"
+	"github.com/spolu/settle/lib/out"
+	"github.com/spolu/settle/mint"
+)
+
+const (
+	// CmdNmClose is the command name.
+	CmdNmClose cli.CmdName = "close"
+)
+
+func init() {
+	cli.Registrar[CmdNmClose] = NewClose
+}
+
+// Close close an existing trustline.
+type Close struct {
+	ID string
+}
+
+// NewClose constructs and initializes the command.
+func NewClose() cli.Command {
+	return &Close{}
+}
+
+// Name returns the command name.
+func (c *Close) Name() cli.CmdName {
+	return CmdNmClose
+}
+
+// Help prints out the help message for the command.
+func (c *Close) Help(
+	ctx context.Context,
+) {
+	out.Normf("\nUsage: ")
+	out.Boldf("settle close <trustline>\n")
+	out.Normf("\n")
+	out.Normf("  Closing a trustline prevents any future use of it.\n")
+	out.Normf("\n")
+	out.Normf("Arguments:\n")
+	out.Boldf("  trustline\n")
+	out.Normf("    The ID of the trustline to close as returned by the ")
+	out.Boldf("list")
+	out.Normf(" command.\n")
+	out.Valuf("    spolu@m.settle.network[offer_Z1vJtLYFUFgSWwy0]\n")
+	out.Normf("\n")
+	out.Normf("Examples:\n")
+	out.Valuf("  settle close spolu@m.settle.network[offer_Z1vJtLYFUFgSWwy0]\n")
+	out.Normf("\n")
+}
+
+// Parse parses the arguments passed to the command.
+func (c *Close) Parse(
+	ctx context.Context,
+	args []string,
+) error {
+	creds := cli.GetCredentials(ctx)
+	if creds == nil {
+		return errors.Trace(
+			errors.Newf("You need to be logged in (try `settle help login`)."))
+	}
+
+	if len(args) == 0 {
+		return errors.Trace(
+			errors.Newf("Trustline ID required."))
+	}
+	id, args := args[0], args[1:]
+
+	_, _, err := mint.NormalizedOwnerAndTokenFromID(ctx, id)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	c.ID = id
+
+	return nil
+}
+
+// Execute the command or return a human-friendly error.
+func (c *Close) Execute(
+	ctx context.Context,
+) error {
+	// Retrieve offer to check existence
+	offer, err := RetrieveOffer(ctx, c.ID)
+	if err != nil {
+		return errors.Trace(err)
+	} else if offer == nil {
+		return errors.Trace(
+			errors.Newf("Offer does not exists."))
+	}
+
+	out.Boldf("Trustline to close:\n")
+	out.Normf("  ID        : ")
+	out.Valuf("%s\n", offer.ID)
+	out.Normf("  Created   : ")
+	out.Valuf("%d\n", offer.Created)
+	out.Normf("  Owner     : ")
+	out.Valuf("%s\n", offer.Owner)
+	out.Normf("  Pair      : ")
+	out.Valuf("%s\n", offer.Pair)
+	out.Normf("  Price     : ")
+	out.Valuf("%s\n", offer.Price)
+	out.Normf("  Amount    : ")
+	out.Valuf("%s\n", offer.Amount.String())
+	out.Normf("  Status    : ")
+	out.Valuf("%s\n", offer.Status)
+	out.Normf("  Remainder : ")
+	out.Valuf("%s\n", offer.Remainder.String())
+
+	if err := Confirm(ctx, "close"); err != nil {
+		return errors.Trace(err)
+	}
+
+	offer, err = CloseOffer(ctx, c.ID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	out.Boldf("Trustline closed:\n")
+	out.Normf("  ID        : ")
+	out.Valuf("%s\n", offer.ID)
+	out.Normf("  Created   : ")
+	out.Valuf("%d\n", offer.Created)
+	out.Normf("  Owner     : ")
+	out.Valuf("%s\n", offer.Owner)
+	out.Normf("  Pair      : ")
+	out.Valuf("%s\n", offer.Pair)
+	out.Normf("  Price     : ")
+	out.Valuf("%s\n", offer.Price)
+	out.Normf("  Amount    : ")
+	out.Valuf("%s\n", offer.Amount.String())
+	out.Normf("  Status    : ")
+	out.Valuf("%s\n", offer.Status)
+	out.Normf("  Remainder : ")
+	out.Valuf("%s\n", offer.Remainder.String())
+
+	return nil
+}

--- a/cli/command/help.go
+++ b/cli/command/help.go
@@ -62,9 +62,14 @@ func (c *Help) Help(
 	out.Valuf("    settle pay von.neumann@ias.edu GBP.2 20\n")
 	out.Normf("\n")
 
-	out.Boldf("  list <object>\n")
+	out.Boldf("  list <type>\n")
 	out.Normf("    List balances, assets, trustlines.\n")
 	out.Valuf("    settle list balances\n")
+	out.Normf("\n")
+
+	out.Boldf("  close <trustline>\n")
+	out.Normf("    Close a trustline.\n")
+	out.Valuf("    settle close spolu@m.settle.network[offer_Z1vJtLYFUFgSWwy0]\n")
 	out.Normf("\n")
 
 	out.Boldf("  login\n")

--- a/cli/command/list.go
+++ b/cli/command/list.go
@@ -67,10 +67,10 @@ func (c *List) Help(
 	out.Valuf("    USD.2 HOUR-OF-WORK.0 BTC.7 EUR.2 DRINK.0\n")
 	out.Normf("\n")
 	out.Normf("Examples:\n")
-	out.Valuf("   setlle list assets\n")
-	out.Valuf("   setlle list balances\n")
-	out.Valuf("   setlle list balances USD.2\n")
-	out.Valuf("   setlle list trustlines EUR.2\n")
+	out.Valuf("  setlle list assets\n")
+	out.Valuf("  setlle list balances\n")
+	out.Valuf("  setlle list balances USD.2\n")
+	out.Valuf("  setlle list trustlines EUR.2\n")
 	out.Normf("\n")
 }
 
@@ -151,7 +151,11 @@ func (c *List) OutList(
 		out.Normf(" ")
 		for _, v := range d {
 			out.Normf(" %s: ", v[0])
-			out.Valuf("%s", v[1])
+			if v[0] == "Status" && v[1] == string(mint.OfStClosed) {
+				out.Errof("%s", v[1])
+			} else {
+				out.Valuf("%s", v[1])
+			}
 		}
 		out.Normf("\n")
 	}
@@ -237,6 +241,7 @@ func (c *List) ExecuteTrustlines(
 	data := [][][2]string{}
 	for _, o := range cOffers {
 		data = append(data, [][2]string{
+			[2]string{"ID", o.ID},
 			[2]string{"Pair", o.Pair},
 			[2]string{"Price", o.Price},
 			[2]string{"Amount", o.Amount.String()},
@@ -254,6 +259,7 @@ func (c *List) ExecuteTrustlines(
 	data = [][][2]string{}
 	for _, o := range pOffers {
 		data = append(data, [][2]string{
+			[2]string{"ID", o.ID},
 			[2]string{"Pair", o.Pair},
 			[2]string{"Price", o.Price},
 			[2]string{"Amount", o.Amount.String()},

--- a/cli/command/mint.go
+++ b/cli/command/mint.go
@@ -55,9 +55,9 @@ func (c *Mint) Help(
 	out.Valuf("    USD.2 HOUR-OF-WORK.0 BTC.7 EUR.2 DRINK.0\n")
 	out.Normf("\n")
 	out.Normf("Examples:\n")
-	out.Valuf("   setlle mint USD.2\n")
-	out.Valuf("   setlle mint BTC.7\n")
-	out.Valuf("   setlle mint HOUR-Of-WORK.0\n")
+	out.Valuf("  setlle mint USD.2\n")
+	out.Valuf("  setlle mint BTC.7\n")
+	out.Valuf("  setlle mint HOUR-Of-WORK.0\n")
 	out.Normf("\n")
 }
 

--- a/cli/command/pay.go
+++ b/cli/command/pay.go
@@ -108,7 +108,7 @@ func (c *Pay) Help(
 	out.Valuf("    42\n")
 	out.Normf("\n")
 	out.Normf("Examples:\n")
-	out.Valuf("   setlle pay von.neumann@ias.edu EUR.2 150\n")
+	out.Valuf("  setlle pay von.neumann@ias.edu EUR.2 150\n")
 	out.Normf("\n")
 }
 

--- a/cli/command/trust.go
+++ b/cli/command/trust.go
@@ -90,10 +90,10 @@ func (c *Trust) Help(
 	out.Valuf("    1/1 100/125 4500/1\n")
 	out.Normf("\n")
 	out.Normf("Examples:\n")
-	out.Valuf("   setlle trust von.neumann@ias.edu USD.2 150\n")
-	out.Valuf("   setlle trust kurt@princetown.edu USD.2 150 with USD.2 at 1/1\n")
-	out.Valuf("   setlle trust alan@npl.co.uk GBP.2 120 with USD.2 at 125/100\n")
-	out.Valuf("   setlle trust venture@risky.co USD.2 1200 with USD.2 at 100/75\n")
+	out.Valuf("  setlle trust von.neumann@ias.edu USD.2 150\n")
+	out.Valuf("  setlle trust kurt@princetown.edu USD.2 150 with USD.2 at 1/1\n")
+	out.Valuf("  setlle trust alan@npl.co.uk GBP.2 120 with USD.2 at 125/100\n")
+	out.Valuf("  setlle trust venture@risky.co USD.2 1200 with USD.2 at 100/75\n")
 	out.Normf("\n")
 }
 


### PR DESCRIPTION
Adds the `close` command to the `settle` command line:
```
spolu@st-stan1:~$ Go/bin/settle -env=qa help close
[Initializing] env=qa user=spolu@m.settle.network

Usage: settle close <trustline>

  Closing a trustline prevents any future use of it.

Arguments:
  trustline
    The ID of the trustline to close as returned by the list command.
    spolu@m.settle.network[offer_Z1vJtLYFUFgSWwy0]

Examples:
  settle close spolu@m.settle.network[offer_Z1vJtLYFUFgSWwy0]
```

cc @gyril 