### PR TITLE
Transactions Memo

### DIFF
--- a/mint/endpoint/create_transaction.go
+++ b/mint/endpoint/create_transaction.go
@@ -44,6 +44,7 @@ type CreateTransaction struct {
 	Amount      big.Int
 	Destination string
 	Path        []string
+	Memo        *string
 
 	// State
 	Tx   *model.Transaction
@@ -133,6 +134,13 @@ func (e *CreateTransaction) Validate(
 			return errors.Trace(err)
 		}
 		e.Path = path
+
+		// Validate memo.
+		memo, err := ValidateMemo(ctx, r.PostFormValue("memo"))
+		if err != nil {
+			return errors.Trace(err)
+		}
+		e.Memo = memo
 	}
 
 	return nil
@@ -172,6 +180,7 @@ func (e *CreateTransaction) ExecuteCanonical(
 		e.Destination,
 		model.OfPath(e.Path),
 		mint.TxStPending,
+		e.Memo,
 	)
 	if err != nil {
 		return nil, nil, errors.Trace(err) // 500
@@ -326,6 +335,7 @@ func (e *CreateTransaction) ExecutePropagated(
 			model.OfPath(e.Path),
 			mint.TxStPending,
 			transaction.Lock,
+			transaction.Memo,
 		)
 		if err != nil {
 			return nil, nil, errors.Trace(err) // 500

--- a/mint/endpoint/validations.go
+++ b/mint/endpoint/validations.go
@@ -259,3 +259,22 @@ func ValidatePropagation(
 
 	return &p, nil
 }
+
+// ValidateMemo validates a memo.
+func ValidateMemo(
+	ctx context.Context,
+	memo string,
+) (*string, error) {
+	if int64(len(memo)) > mint.MemoMaxLength {
+		return nil, errors.Trace(errors.NewUserErrorf(nil,
+			400, "memo_invalid",
+			"The memo you provided exceeds the maximum length (%d): %s.",
+			mint.MemoMaxLength, memo,
+		))
+	}
+
+	if len(memo) == 0 {
+		return nil, nil
+	}
+	return &memo, nil
+}

--- a/mint/model/schemas/mint.5.transactions.go
+++ b/mint/model/schemas/mint.5.transactions.go
@@ -20,6 +20,8 @@ CREATE TABLE IF NOT EXISTS transactions(
   lock VARCHAR(256) NOT NULL,        -- lock = hex(scrypt(secret, id))
   secret VARCHAR(256),               -- lock secret
 
+  memo VARCHAR(1024),                -- memo
+
   PRIMARY KEY(owner, token)
 );
 `

--- a/mint/protocol.go
+++ b/mint/protocol.go
@@ -11,6 +11,8 @@ const (
 	// TransactionExpiryMs is the time it takes to attempt to cancel a
 	// transaction for this mint. Expressed in ms.
 	TransactionExpiryMs int64 = 1000 * 60 * 60
+	// MemoMaxLength is the maximal length of a transaction's memo string.
+	MemoMaxLength int64 = 1024
 )
 
 // PgType is the propagation type of an object.
@@ -139,6 +141,8 @@ type TransactionResource struct {
 	Status TxStatus `json:"status"`
 	Lock   string   `json:"lock"`
 	Secret *string  `json:"secret"`
+
+	Memo *string `json:"memo"`
 
 	Operations []OperationResource `json:"operations"`
 	Crossings  []CrossingResource  `json:"crossings"`


### PR DESCRIPTION
Adds support for transaction memos, 1024 byte strings attached to a transaction intended to support online payments:
- Merchant generates Memo and ask customer to create a transaction with it.
- Merchant reconcile transactions to orders with the memo.